### PR TITLE
Add Argo app of apps example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Workflows-CI
+
+This repository contains an example Argo **app-of-apps** configuration that
+deploys workflow templates and an event sensor for building Docker and Helm
+artifacts. The build pulls source from `gogs.local` and pushes container images
+and Helm charts to `harbor.local/library`.
+
+## Files
+
+- `argo/app-of-apps.yaml` – Root Argo CD application that loads child apps from
+the `argo/applications` folder.
+- `argo/applications/workflows-app.yaml` – Deploys the workflow templates
+  located under `argo/workflows`.
+- `argo/workflows/build-workflow-template.yaml` – Workflow template that lints,
+  tests, builds and pushes Docker images and Helm charts.
+- `argo/events/gogs-event-source.yaml` – EventSource for receiving Gogs
+  webhooks.
+- `argo/events/build-sensor.yaml` – Sensor that triggers the build workflow when
+a webhook event is received.
+
+Credentials for accessing Gogs and pushing to Harbor must be provided through
+Kubernetes secrets named `gogs-credentials` and `harbor-credentials`. Additional
+parameters can be set via workflow or sensor arguments.

--- a/argo/app-of-apps.yaml
+++ b/argo/app-of-apps.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workflows-ci-app-of-apps
+spec:
+  project: default
+  source:
+    repoURL: https://gogs.local/Workflows-CI.git
+    targetRevision: HEAD
+    path: argo/applications
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argo/applications/workflows-app.yaml
+++ b/argo/applications/workflows-app.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workflows-ci
+spec:
+  project: default
+  source:
+    repoURL: https://gogs.local/Workflows-CI.git
+    targetRevision: HEAD
+    path: argo/workflows
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argo/events/build-sensor.yaml
+++ b/argo/events/build-sensor.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: build-sensor
+spec:
+  template:
+    serviceAccountName: argo-events-sa
+  dependencies:
+    - name: gogs-push
+      eventSourceName: gogs
+      eventName: gogs
+  triggers:
+    - template:
+        name: build-workflow
+        argoWorkflow:
+          group: argoproj.io
+          version: v1alpha1
+          resource: workflow
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: build-
+              spec:
+                workflowTemplateRef:
+                  name: build-and-push
+                arguments:
+                  parameters:
+                    - name: repo
+                      value: https://gogs.local/my-org/my-repo.git
+                    - name: image
+                      value: harbor.local/library/my-app:latest

--- a/argo/events/gogs-event-source.yaml
+++ b/argo/events/gogs-event-source.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: gogs
+spec:
+  service:
+    ports:
+      - port: 12000
+        targetPort: 12000
+  webhook:
+    gogs:
+      endpoint: /
+      port: "12000"
+      method: POST
+      url: /
+      authSecret:
+        name: gogs-secret
+        key: token

--- a/argo/workflows/build-workflow-template.yaml
+++ b/argo/workflows/build-workflow-template.yaml
@@ -1,0 +1,113 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: build-and-push
+spec:
+  serviceAccountName: argo-workflow
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: checkout
+        template: git-checkout
+      - name: lint
+        template: lint
+        dependencies: [checkout]
+      - name: test
+        template: test
+        dependencies: [checkout]
+      - name: build
+        template: build-image
+        dependencies: [lint, test]
+      - name: helm
+        template: helm-package
+        dependencies: [build]
+      - name: push-image
+        template: push-image
+        dependencies: [build]
+      - name: push-chart
+        template: push-chart
+        dependencies: [helm]
+  - name: git-checkout
+    inputs:
+      parameters:
+      - name: repo
+        value: "{{workflow.parameters.repo}}"
+    container:
+      image: alpine/git
+      command: [sh, -c]
+      args: ["git clone https://$GOGS_USERNAME:$GOGS_PASSWORD@{{inputs.parameters.repo}} source"]
+      envFrom:
+      - secretRef:
+          name: gogs-credentials
+  - name: lint
+    container:
+      image: golang:1.20
+      workingDir: /src/source
+      command: [sh, -c]
+      args: ["go vet ./..."]
+      volumeMounts:
+      - name: workdir
+        mountPath: /src
+  - name: test
+    container:
+      image: golang:1.20
+      workingDir: /src/source
+      command: [sh, -c]
+      args: ["go test ./..."]
+      volumeMounts:
+      - name: workdir
+        mountPath: /src
+  - name: build-image
+    container:
+      image: gcr.io/kaniko-project/executor:latest
+      command: ["/kaniko/executor"]
+      args:
+        - "--dockerfile=/src/source/Dockerfile"
+        - "--context=/src/source"
+        - "--destination={{workflow.parameters.image}}"
+      volumeMounts:
+      - name: workdir
+        mountPath: /src
+      envFrom:
+      - secretRef:
+          name: harbor-credentials
+  - name: push-image
+    container:
+      image: alpine
+      command: [sh, -c]
+      args: ["echo pushed $IMAGE"]
+      env:
+      - name: IMAGE
+        value: "{{workflow.parameters.image}}"
+  - name: helm-package
+    container:
+      image: alpine/helm:3.12.2
+      workingDir: /src/source/chart
+      command: [sh, -c]
+      args: ["helm dependency update && helm package ."]
+      volumeMounts:
+      - name: workdir
+        mountPath: /src
+  - name: push-chart
+    container:
+      image: curlimages/curl
+      workingDir: /src/source/chart
+      command: [sh, -c]
+      args: ["curl -u $HARBOR_USERNAME:$HARBOR_PASSWORD --data-binary @*.tgz http://harbor.local/chartrepo/library/charts"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /src
+      envFrom:
+      - secretRef:
+          name: harbor-credentials
+  volumes:
+  - name: workdir
+    emptyDir: {}
+  arguments:
+    parameters:
+    - name: repo
+      value: https://gogs.local/my-org/my-repo.git
+    - name: image
+      value: harbor.local/library/my-app:latest


### PR DESCRIPTION
## Summary
- add README with overview
- create Argo CD app-of-apps configuration
- add workflow template for linting, testing, building and pushing images and helm charts
- add Argo Events sensor and event source for Gogs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854c75bd9c883209c9a5e63ceeaac54